### PR TITLE
Adding a missing repos=repos

### DIFF
--- a/install_R_dependencies.R
+++ b/install_R_dependencies.R
@@ -19,7 +19,7 @@ if (!require("tximport") | !require("edgeR")) {
         biocLite("edgeR")
     } else {
         if (!requireNamespace("BiocManager", quietly = TRUE)) {
-            install.packages("BiocManager")
+            install.packages("BiocManager", repos=repos)
         }
         BiocManager::install("tximport")
         BiocManager::install("edgeR")


### PR DESCRIPTION
I had issues with this script, which seems to be solved by adding the `repos=repos` for BiocManager.